### PR TITLE
Add Tesserae to DIY

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ PocketBook readers:
 - [EPDiy](https://github.com/vroland/epdiy) - ESP32 based driver board for eink panel.
 - [BeepBerry](https://ericmigi.com/blog/introducing-beepberry-a-portable-e-paper-computer-for-hackers) - a portable e-paper computer for hackers (based on RaspberryPi Zero W )
 - [Kindle Side Card](https://github.com/perduewu-ops/kindle-side-card) - local-first dashboard that turns a jailbroken Kindle into a desktop side display.
+- [Tesserae](https://github.com/dmellok/tesserae) - self-hosted e-ink dashboard server with multi-device push to Pi, ESP32, jailbroken Kindle, and TRMNL panels.
 
 ## Great resources about e-ink
 - [My Deep Guide](https://www.youtube.com/@MyDeepGuide) - High-quality reviews from e-ink technology enthusiast.


### PR DESCRIPTION
## What's being added

[Tesserae](https://github.com/dmellok/tesserae), a self-hosted e-ink dashboard server that composes tile layouts in the browser and pushes the rendered frames to multiple e-ink panels.

Fits the **DIY** section alongside Kindle Side Card and BeepBerry as a software / appliance project for makers building their own e-ink setups.

## Why it's awesome

- **Multi-device by design**: one server drives Raspberry Pi panels, ESP32-based boards (Pimoroni Inky, Waveshare Spectra 6), jailbroken Kindles via the TRMNL BYOS protocol, native TRMNL devices, and KOReader displays. Multi-head dashboards across different panel sizes work out of the box.
- **Drop-a-folder plugin model** for widgets, renderers, and devices. Adding new hardware support or a new widget is a contained change, not a fork.
- **30 bundled widgets** plus a [community catalog](https://github.com/dmellok/tesserae-widgets) of 16 more, one-click installable from the admin UI.
- **Home Assistant integration**: MQTT auto-discovery, webhook push, and a dedicated HA App in the official add-on store.
- **Active development**, current release [v0.64.8](https://github.com/dmellok/tesserae/releases/latest), AGPL-3.0-or-later.

## Resources

- Documentation: https://dmellok.github.io/tesserae/
- Widget gallery: https://dmellok.github.io/tesserae/widgets/gallery/
- Architecture deep dive: https://dmellok.github.io/tesserae/dev/architecture/
- Client protocol spec: https://dmellok.github.io/tesserae/dev/client-protocol/

Following the [contributing guidelines](CONTRIBUTING.md): description is brief, link is the official repository, placement at the end of DIY matches the existing software-project ordering.
