### PR TITLE
Add Ferrink - Rust launcher for Kindle E Ink readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ PocketBook readers:
 - [Soldered Inkplate](https://soldered.com/categories/inkplate/) - ESP32 based WiFi ready all-in-one e-ink boards
 - [EPDiy](https://github.com/vroland/epdiy) - ESP32 based driver board for eink panel.
 - [Ferrink](https://github.com/justinledwards/ferrink) - Rust launcher and home screen replacement for E Ink readers (Kindle). Opens locally installed apps and returns when they close.
+- [Ferrink Home Assistant](https://github.com/justinledwards/ferrink-home-assistant) - Native touch-controlled e-ink dashboard for jailbroken Kindles that talks directly to Home Assistant. Renders climate, lights, and calendar without a browser.
 - [Glider](https://gitlab.com/zephray/glider) - HDMI input driver board for eink panel. Plenty of useful information on the README too.
 - [BeepBerry](https://ericmigi.com/blog/introducing-beepberry-a-portable-e-paper-computer-for-hackers) - a portable e-paper computer for hackers (based on RaspberryPi Zero W )
 - [Kindle Side Card](https://github.com/perduewu-ops/kindle-side-card) - local-first dashboard that turns a jailbroken Kindle into a desktop side display.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ PocketBook readers:
 - [Waveshare e-ink modules](https://www.waveshare.com/product/displays/e-paper.htm) - e-ink modules for DIY projects from Waveshare.
 - [Adafruit e-ink modules](https://www.adafruit.com/category/150) - e-ink modules for DIY projects from Adafruit.
 - [Soldered Inkplate](https://soldered.com/categories/inkplate/) - ESP32 based WiFi ready all-in-one e-ink boards
-- [Glider](https://gitlab.com/zephray/glider) - HDMI input driver board for eink panel. Plenty of useful information on the README too.
 - [EPDiy](https://github.com/vroland/epdiy) - ESP32 based driver board for eink panel.
+- [Ferrink](https://github.com/justinledwards/ferrink) - Rust launcher and home screen replacement for E Ink readers (Kindle). Opens locally installed apps and returns when they close.
+- [Glider](https://gitlab.com/zephray/glider) - HDMI input driver board for eink panel. Plenty of useful information on the README too.
 - [BeepBerry](https://ericmigi.com/blog/introducing-beepberry-a-portable-e-paper-computer-for-hackers) - a portable e-paper computer for hackers (based on RaspberryPi Zero W )
 - [Kindle Side Card](https://github.com/perduewu-ops/kindle-side-card) - local-first dashboard that turns a jailbroken Kindle into a desktop side display.
 - [Tesserae](https://github.com/dmellok/tesserae) - self-hosted e-ink dashboard server with multi-device push to Pi, ESP32, jailbroken Kindle, and TRMNL panels.


### PR DESCRIPTION
Add [Ferrink](https://github.com/justinledwards/ferrink) to the DIY section.

Ferrink is a Rust-based launcher and home screen replacement for jailbroken Kindle E Ink readers. It fills the gap between "jailbreak your Kindle" and "actually use it for something useful" — replacing the stock launcher with one that opens locally installed apps and returns to the home screen on close.